### PR TITLE
Restarting on crash

### DIFF
--- a/src/events/invalidated.js
+++ b/src/events/invalidated.js
@@ -1,0 +1,7 @@
+module.exports = {
+    name: "invalidated",
+    once: true,
+    execute() {
+        process.exit(1000)
+    },
+};

--- a/src/startup.js
+++ b/src/startup.js
@@ -1,0 +1,42 @@
+const child_process = require("child_process");
+console.log("[ PARENT ] => process is running.");
+start(process.argv[2]);
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function start(nodefile, reboot) {
+    if (typeof nodefile != "string") {
+        return console.log("Give a file name to run");
+    }
+
+    console.log("[ PARENT ] => Spawning Child process.");
+    let child;
+    if (reboot) child = child_process.spawn("node", [nodefile, `${reboot}`]);
+    else child = child_process.spawn("node", [nodefile]);
+
+    child.stdout.on("data", function (data) {
+        console.log(data.toString());
+    });
+
+    child.stderr.on("data", function (data) {
+        console.log(data.toString());
+    });
+
+    child.on("exit", async function (code) {
+        if (code == 1000) return console.log(`[ CHILD ] = > Stopped with code: 1000, rebooting prevented`);
+        console.log("[ PARENT ] => Child process exited with code" + " " + code + "\n");
+        delete proc;
+
+        console.log("Rebooting in 3 seconds");
+        await sleep(994);
+        console.log("Rebooting in 2 seconds");
+        await sleep(994);
+        console.log("Rebooting in 1 second");
+        await sleep(994);
+        console.log("Rebooting in 0 seconds");
+        start(nodefile, code);
+        console.log("Rebooting...");
+    });
+}


### PR DESCRIPTION
Hi, well...
This is tiny thingy is what I use for most of my bots since I'm way too lazy to go to hosting and restart the bot manually.
I just check log file once a week

if you want to redirect all output to file you can add this after the command:
`> bot_logs.log 2>&1`
so the command should look like: 
`node ./startup.js ./index.js > bot_logs.log 2>&1`

this works on both windows and unix
never had opportunity to check on mac

but now explanation time...
first `>` redirects `stdout` to the file

the second part `2>` redirects `stderr`
and at the end we have `&1` this means that we redirect the stderr to the same location as `stdout`
but you can easily change &1 to for example `bot_errors.log` and it will work perfectly fine as well ^-^